### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,10 +16,11 @@ plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
 plugin.org.xtext.xtend=2.0.8
 
-version.com.google.guava..guava=28.2-jre
+version.com.google.guava..guava=29.0-jre
 
 version.junit.junit=4.13
 
 version.org.apache.commons..commons-collections4=4.4
 
 version.org.eclipse.xtend..org.eclipse.xtend.lib=2.21.0
+##                                   # available=2.22.0.M1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.