### PR TITLE
Upgrade org.eclipse.xtend.lib from 2.22.0.M3 to 2.22.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,4 +22,4 @@ version.junit.junit=4.13
 
 version.org.apache.commons..commons-collections4=4.4
 
-version.org.eclipse.xtend..org.eclipse.xtend.lib=2.22.0.M3
+version.org.eclipse.xtend..org.eclipse.xtend.lib=2.22.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.