### PR TITLE
Upgrade guava from 29.0-jre to 30.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,7 +16,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 plugin.org.xtext.xtend=2.0.8
 
-version.com.google.guava..guava=29.0-jre
+version.com.google.guava..guava=30.0-jre
 
 version.junit.junit=4.13.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.