### PR TITLE
Upgrade xtend from 2.0.9 to 2.1.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
-plugin.org.xtext.xtend=2.0.9
+plugin.org.xtext.xtend=2.1.0
 
 version.com.github.spotbugs..spotbugs-annotations=4.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.