### PR TITLE
Upgrade spotbugs-annotations from 4.4.0 to 4.4.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ plugin.org.jlleitschuh.gradle.ktlint=10.2.0
 
 plugin.org.xtext.xtend=2.1.0
 
-version.com.github.spotbugs..spotbugs-annotations=4.4.0
+version.com.github.spotbugs..spotbugs-annotations=4.4.1
 
 version.com.google.guava..guava=30.1.1-jre
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.