### PR TITLE
Upgrade guava from 30.1.1-jre to 31.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,7 +23,7 @@ plugin.org.xtext.xtend=2.1.0
 
 version.com.github.spotbugs..spotbugs-annotations=4.4.1
 
-version.com.google.guava..guava=30.1.1-jre
+version.com.google.guava..guava=31.0-jre
 
 version.detekt=1.18.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.